### PR TITLE
Test cleanup

### DIFF
--- a/test/UniswapV2ERC20.spec.ts
+++ b/test/UniswapV2ERC20.spec.ts
@@ -61,19 +61,23 @@ describe('UniswapV2ERC20', () => {
   })
 
   it('transfer', async () => {
-    expect(await token.transfer(other.address, TEST_AMOUNT))
+    await expect(token.transfer(other.address, TEST_AMOUNT))
+      .to.emit(token, 'Transfer')
+      .withArgs(wallet.address, other.address, TEST_AMOUNT)
     expect(await token.balanceOf(wallet.address)).to.eq(TOTAL_SUPPLY.sub(TEST_AMOUNT))
     expect(await token.balanceOf(other.address)).to.eq(TEST_AMOUNT)
   })
 
-  // it('transfer:fail', async () => {
-  //   await expect(token.transfer(other.address, TOTAL_SUPPLY.add(1))).to.be.reverted // ds-math-sub-underflow
-  //   await expect(token.connect(other).transfer(wallet.address, 1)).to.be.reverted // ds-math-sub-underflow
-  // })
+  it('transfer:fail', async () => {
+    await expect(token.transfer(other.address, TOTAL_SUPPLY.add(1))).to.be.reverted // ds-math-sub-underflow
+    await expect(token.connect(other).transfer(wallet.address, 1)).to.be.reverted // ds-math-sub-underflow
+  })
 
   it('transferFrom', async () => {
     await token.approve(other.address, TEST_AMOUNT)
-    expect(await token.connect(other).transferFrom(wallet.address, other.address, TEST_AMOUNT));
+    await expect(token.connect(other).transferFrom(wallet.address, other.address, TEST_AMOUNT))
+      .to.emit(token, 'Transfer')
+      .withArgs(wallet.address, other.address, TEST_AMOUNT)
     expect(await token.allowance(wallet.address, other.address)).to.eq(0)
     expect(await token.balanceOf(wallet.address)).to.eq(TOTAL_SUPPLY.sub(TEST_AMOUNT))
     expect(await token.balanceOf(other.address)).to.eq(TEST_AMOUNT)
@@ -81,7 +85,9 @@ describe('UniswapV2ERC20', () => {
 
   it('transferFrom:max', async () => {
     await token.approve(other.address, MaxUint256)
-    expect(await token.connect(other).transferFrom(wallet.address, other.address, TEST_AMOUNT))
+    await expect(token.connect(other).transferFrom(wallet.address, other.address, TEST_AMOUNT))
+      .to.emit(token, 'Transfer')
+      .withArgs(wallet.address, other.address, TEST_AMOUNT)
     expect(await token.allowance(wallet.address, other.address)).to.eq(MaxUint256)
     expect(await token.balanceOf(wallet.address)).to.eq(TOTAL_SUPPLY.sub(TEST_AMOUNT))
     expect(await token.balanceOf(other.address)).to.eq(TEST_AMOUNT)

--- a/test/UniswapV2Factory.spec.ts
+++ b/test/UniswapV2Factory.spec.ts
@@ -48,8 +48,8 @@ describe('UniswapV2Factory', () => {
       .to.emit(factory, 'PairCreated')
       .withArgs(TEST_ADDRESSES[0], TEST_ADDRESSES[1], create2Address, bigNumberify(1))
 
-    //await expect(factory.createPair(...tokens)).to.be.reverted // UniswapV2: PAIR_EXISTS
-    //await expect(factory.createPair(...tokens.slice().reverse())).to.be.reverted // UniswapV2: PAIR_EXISTS
+    await expect(factory.createPair(...tokens)).to.be.reverted // UniswapV2: PAIR_EXISTS
+    await expect(factory.createPair(...tokens.slice().reverse())).to.be.reverted // UniswapV2: PAIR_EXISTS
     expect(await factory.getPair(...tokens)).to.eq(create2Address)
     expect(await factory.getPair(...tokens.slice().reverse())).to.eq(create2Address)
     expect(await factory.allPairs(0)).to.eq(create2Address)
@@ -76,15 +76,15 @@ describe('UniswapV2Factory', () => {
   })
 
   it('setFeeTo', async () => {
-    //await expect(factory.connect(other).setFeeTo(other.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
+    await expect(factory.connect(other).setFeeTo(other.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
     await factory.setFeeTo(wallet.address)
     expect(await factory.feeTo()).to.eq(wallet.address)
   })
 
   it('setFeeToSetter', async () => {
-    //await expect(factory.connect(other).setFeeToSetter(other.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
+    await expect(factory.connect(other).setFeeToSetter(other.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
     await factory.setFeeToSetter(other.address)
     expect(await factory.feeToSetter()).to.eq(other.address)
-    //await expect(factory.setFeeToSetter(wallet.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
+    await expect(factory.setFeeToSetter(wallet.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
   })
 })

--- a/test/UniswapV2Pair.spec.ts
+++ b/test/UniswapV2Pair.spec.ts
@@ -23,9 +23,7 @@ describe('UniswapV2Pair', () => {
   // })
   // const [wallet, other] = provider.getWallets()
 
-  //const provider = new providers.Web3Provider( {host:"http://127.0.0.1:9090/solana"})
   const provider = new providers.JsonRpcProvider("http://127.0.0.1:9090/solana");
-  //const provider = new providers.Web3Provider(currentProvider)
   const wallet = new Wallet("0xd191daa598a77767eae21d33c865422f95a01f705bc4fbef8271d46177b075be", provider)
   const other = Wallet.createRandom().connect(provider)
 
@@ -90,9 +88,9 @@ describe('UniswapV2Pair', () => {
       const [swapAmount, token0Amount, token1Amount, expectedOutputAmount] = swapTestCase
       await addLiquidity(token0Amount, token1Amount)
       await token0.transfer(pair.address, swapAmount)
-//      await expect(pair.swap(0, expectedOutputAmount.add(1), wallet.address, '0x', overrides)).to.be.revertedWith(
-//        'UniswapV2: K'
-//      )
+      await expect(pair.swap(0, expectedOutputAmount.add(1), wallet.address, '0x', overrides)).to.be.revertedWith(
+        'UniswapV2: K'
+      )
       await pair.swap(0, expectedOutputAmount, wallet.address, '0x', overrides)
     })
   })
@@ -108,9 +106,9 @@ describe('UniswapV2Pair', () => {
       const [outputAmount, token0Amount, token1Amount, inputAmount] = optimisticTestCase
       await addLiquidity(token0Amount, token1Amount)
       await token0.transfer(pair.address, inputAmount)
- //     await expect(pair.swap(outputAmount.add(1), 0, wallet.address, '0x', overrides)).to.be.revertedWith(
- //       'UniswapV2: K'
- //     )
+      await expect(pair.swap(outputAmount.add(1), 0, wallet.address, '0x', overrides)).to.be.revertedWith(
+        'UniswapV2: K'
+      )
       await pair.swap(outputAmount, 0, wallet.address, '0x', overrides)
     })
   })

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -38,7 +38,7 @@ export async function pairFixture(provider:JsonRpcProvider, [wallet]: Wallet[]):
   const pairAddress = await factory.getPair(tokenA.address, tokenB.address)
   const pair = new Contract(pairAddress, JSON.stringify(UniswapV2Pair.abi), provider).connect(wallet)
 
-  const token0Address = (await pair.token0()).address
+  const token0Address = (await pair.token0())
   const token0 = tokenA.address === token0Address ? tokenA : tokenB
   const token1 = tokenA.address === token0Address ? tokenB : tokenA
 

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -1,5 +1,5 @@
 import { Contract } from 'ethers'
-import { Web3Provider } from 'ethers/providers'
+import {JsonRpcProvider, Web3Provider} from 'ethers/providers'
 import {
   BigNumber,
   bigNumberify,
@@ -26,7 +26,7 @@ function getDomainSeparator(name: string, tokenAddress: string) {
         keccak256(toUtf8Bytes('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)')),
         keccak256(toUtf8Bytes(name)),
         keccak256(toUtf8Bytes('1')),
-        1,
+        0,
         tokenAddress
       ]
     )

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -79,20 +79,20 @@ export async function getApprovalDigest(
   )
 }
 
-export async function mineBlock(provider: Web3Provider, timestamp: number): Promise<void> {
-  await new Promise(async (resolve, reject) => {
-    ;(provider._web3Provider.sendAsync as any)(
-      { jsonrpc: '2.0', method: 'evm_mine', params: [timestamp] },
-      (error: any, result: any): void => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(result)
-        }
-      }
-    )
-  })
-}
+// export async function mineBlock(provider: Web3Provider, timestamp: number): Promise<void> {
+//   await new Promise(async (resolve, reject) => {
+//     ;(provider._web3Provider.sendAsync as any)(
+//       { jsonrpc: '2.0', method: 'evm_mine', params: [timestamp] },
+//       (error: any, result: any): void => {
+//         if (error) {
+//           reject(error)
+//         } else {
+//           resolve(result)
+//         }
+//       }
+//     )
+//   })
+// }
 
 export function encodePrice(reserve0: BigNumber, reserve1: BigNumber) {
   return [reserve1.mul(bigNumberify(2).pow(112)).div(reserve0), reserve0.mul(bigNumberify(2).pow(112)).div(reserve1)]


### PR DESCRIPTION
Restore tests to mainstream state.
Fix invalid token0/token1 assignment in Pair fixture (random test faults)
Rewrite UniswapV2Pair price{0,1}CumulativeLast test (get the actual timestamp from the contract and use it to compute expected values)