### PR TITLE
neonlabsorg/proxy_model.py#809 speedup tests on mempool

### DIFF
--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -33,8 +33,7 @@ export NEON_EVM_COMMIT=latest
 export FAUCET_COMMIT=latest
 docker pull neonlabsorg/proxy:latest
 docker run --rm --entrypoint cat neonlabsorg/proxy:latest proxy/docker-compose-test.yml > node-and-proxy.yml
-
-docker-compose -f node-and-proxy.yml up -d
+docker-compose -f node-and-proxy.yml pull
 
 function cleanup_docker {
     echo "Cleanup docker-compose..."
@@ -42,10 +41,16 @@ function cleanup_docker {
     echo "Cleanup docker-compose done."
 }
 trap cleanup_docker EXIT
-sleep 10
 
-export REVISION=$(git rev-parse HEAD)
-UNISWAP_V2_CORE_IMAGE=neonlabsorg/uniswap-v2-core:${IMAGETAG:-$REVISION}
+echo "Cleanup docker-compose..."
+docker-compose -f node-and-proxy.yml down -t 1
+if ! docker-compose -f node-and-proxy.yml up -d; then
+  echo "docker-compose failed to start"
+  exit 1;
+fi
+
+export UNISWAP_REVISION=$(git rev-parse HEAD)
+UNISWAP_V2_CORE_IMAGE=neonlabsorg/uniswap-v2-core:${IMAGETAG:-$UNISWAP_REVISION}
 
 export PROXY_URL=http://127.0.0.1:9090/solana
 

--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -37,8 +37,10 @@ docker-compose -f node-and-proxy.yml pull
 
 function cleanup_docker {
     echo "Cleanup docker-compose..."
-    docker-compose -f node-and-proxy.yml down --rmi 'all'
+    docker-compose -f node-and-proxy.yml down -t 1
     echo "Cleanup docker-compose done."
+    echo "Removing temporary data volumes..."
+    docker volume prune -f
 }
 trap cleanup_docker EXIT
 

--- a/test/UniswapV2Pair.spec.ts
+++ b/test/UniswapV2Pair.spec.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai'
 import { Contract, providers, Wallet, BigNumber, constants } from 'ethers'
 import { solidity } from 'ethereum-waffle'
 
-import { expandTo18Decimals, encodePrice, wait_for_tx_complete } from './shared/utilities'
+import { expandTo18Decimals, encodePrice, wait_for_tx_complete, sleep } from './shared/utilities'
 import { pairFixture } from './shared/fixtures'
 const { AddressZero } = constants
 
@@ -228,23 +228,18 @@ describe('UniswapV2Pair', () => {
   })
 
   it('price{0,1}CumulativeLast', async () => {
-    function sleep(ms: number) {
-      return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-      });
-    }
     const token0Amount = expandTo18Decimals(3)
     const token1Amount = expandTo18Decimals(3)
     await addLiquidity(token0Amount, token1Amount)
 
     const reserves0 = (await pair.getReserves())
-    await sleep(500);
+    await sleep(1000);
     //await mineBlock(provider, blockTimestamp + 1)
 
     const tx1 = await pair.sync(overrides)
     await wait_for_tx_complete(provider, tx1.hash)
     const reserves1 = (await pair.getReserves())
-    await sleep(500);
+    await sleep(1000);
 
     const initialPrice = encodePrice(token0Amount, token1Amount)
     const timeElapsed1 = reserves1[2] - reserves0[2]
@@ -261,7 +256,7 @@ describe('UniswapV2Pair', () => {
     const tx3 = await pair.swap(0, expandTo18Decimals(1), wallet.address, '0x', overrides) // make the price nice
     await wait_for_tx_complete(provider, tx3.hash)
     const reserves2 = (await pair.getReserves())
-    await sleep(500);
+    await sleep(1000);
 
     const timeElapsed2 = reserves2[2] - reserves1[2]
     expect(timeElapsed2).to.not.eq(0)

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -2,7 +2,7 @@ import { Contract, Wallet, providers } from 'ethers'
 const { JsonRpcProvider } = providers
 import { deployContract } from 'ethereum-waffle'
 
-import { expandTo18Decimals } from './utilities'
+import { expandTo18Decimals, wait_for_tx_complete } from './utilities'
 
 import ERC20 from '../../build/ERC20.json'
 import UniswapV2Factory from '../../build/UniswapV2Factory.json'
@@ -34,7 +34,7 @@ export async function pairFixture(provider: InstanceType<typeof JsonRpcProvider>
   const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
 
   const tx = await factory.createPair(tokenA.address, tokenB.address, overrides)
-  await tx.wait()
+  await wait_for_tx_complete(provider, tx.hash)
 
   const pairAddress = await factory.getPair(tokenA.address, tokenB.address)
   const pair = new Contract(pairAddress, JSON.stringify(UniswapV2Pair.abi), provider).connect(wallet)

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -105,15 +105,15 @@ export async function sleep(ms: number) {
 }
 
 export async function wait_for_tx_complete(provider: Provider, transactonHash: string) {
-  const MAX_WAIT_TIMEOUT = 30000
-  const WAIT_TIMEOUT = 100
+  const MAX_WAIT_TIMEOUT_MSEC = 30000
+  const WAIT_TIMEOUT_MSEC = 100
   let timeout = 0
-  while(timeout < MAX_WAIT_TIMEOUT) { 
+  while(timeout < MAX_WAIT_TIMEOUT_MSEC) { 
     const transactionReceipt = await provider.getTransactionReceipt(transactonHash);
     if (transactionReceipt != null) {
       break;
     }
-    await sleep(WAIT_TIMEOUT)
-    timeout += WAIT_TIMEOUT
+    await sleep(WAIT_TIMEOUT_MSEC)
+    timeout += WAIT_TIMEOUT_MSEC
   }
 }

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -98,6 +98,12 @@ export function encodePrice(reserve0: BigNumber, reserve1: BigNumber) {
   return [reserve1.mul(BigNumber.from(2).pow(112)).div(reserve0), reserve0.mul(BigNumber.from(2).pow(112)).div(reserve1)]
 }
 
+export async function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 export async function wait_for_tx_complete(provider: Provider, transactonHash: string) {
   const MAX_WAIT_TIMEOUT = 30000
   const WAIT_TIMEOUT = 100
@@ -107,7 +113,7 @@ export async function wait_for_tx_complete(provider: Provider, transactonHash: s
     if (transactionReceipt != null) {
       break;
     }
-    await new Promise(f => setTimeout(f, WAIT_TIMEOUT));
+    await sleep(WAIT_TIMEOUT)
     timeout += WAIT_TIMEOUT
   }
 }

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -1,4 +1,5 @@
 import { BigNumber, Contract, utils } from 'ethers'
+import { Provider } from "@ethersproject/abstract-provider";
 const {
   getAddress,
   keccak256,
@@ -95,4 +96,18 @@ export async function getApprovalDigest(
 
 export function encodePrice(reserve0: BigNumber, reserve1: BigNumber) {
   return [reserve1.mul(BigNumber.from(2).pow(112)).div(reserve0), reserve0.mul(BigNumber.from(2).pow(112)).div(reserve1)]
+}
+
+export async function wait_for_tx_complete(provider: Provider, transactonHash: string) {
+  const MAX_WAIT_TIMEOUT = 30000
+  const WAIT_TIMEOUT = 100
+  let timeout = 0
+  while(timeout < MAX_WAIT_TIMEOUT) { 
+    const transactionReceipt = await provider.getTransactionReceipt(transactonHash);
+    if (transactionReceipt != null) {
+      break;
+    }
+    await new Promise(f => setTimeout(f, WAIT_TIMEOUT));
+    timeout += WAIT_TIMEOUT
+  }
 }


### PR DESCRIPTION
Speeded up tx waits. 12m -> 6m
`deployContract` is botleneck now. Only solution for further speed up is to patch node modules and bring parallel tests execution.